### PR TITLE
Add and integrate money

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "bootsnap", require: false
 
 gem "sidekiq", "~> 7.2"
 gem 'oj'
+gem 'money'
 
 group :development, :test do
   gem 'rspec-rails', '~> 6.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,8 @@ GEM
     marcel (1.0.4)
     mini_mime (1.1.5)
     minitest (5.22.2)
+    money (6.19.0)
+      i18n (>= 0.6.4, <= 2)
     msgpack (1.7.2)
     mutex_m (0.2.0)
     net-imap (0.4.10)
@@ -239,6 +241,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   jbuilder
+  money
   oj
   pg
   puma (>= 5.0)

--- a/app/models/concerns/moneyable.rb
+++ b/app/models/concerns/moneyable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Concern for instance related to a money.
+#
+# Define <attribute>_money to get the Money version.
+#
+module Moneyable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def with_money_on(*args)
+      args.each do |attribute|
+        define_method "#{attribute.to_s}_money" do
+          value = public_send(attribute)
+
+          return if value.nil?
+
+          Money.from_amount(value)
+        end
+      end
+    end
+  end
+end

--- a/app/models/disbursement.rb
+++ b/app/models/disbursement.rb
@@ -4,6 +4,9 @@
 class Disbursement < ApplicationRecord
   after_initialize :set_defaults
 
+  include Moneyable
+  with_money_on  :orders_amount, :merchant_paid_amount, :total_fees
+
   belongs_to :merchant, inverse_of: :disbursements
   has_many :orders, inverse_of: :disbursement
 

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -5,7 +5,10 @@ class Merchant < ApplicationRecord
   DISBURSEMENT_FREQUENCIES = {
     daily: 'DAILY',
     weekly: 'WEEKLY'
-}.freeze
+  }.freeze
+
+  include Moneyable
+  with_money_on  :minimum_monthly_fee
 
   has_many :orders, inverse_of: :merchant
   has_many :disbursements, inverse_of: :merchant

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,6 +2,9 @@
 
 # Order model
 class Order < ApplicationRecord
+  include Moneyable
+  with_money_on  :amount, :fees
+
   belongs_to :merchant, inverse_of: :orders
   belongs_to :disbursement, inverse_of: :orders, optional: true
 end

--- a/config/initializers/money.rb
+++ b/config/initializers/money.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+Money.rounding_mode = BigDecimal::ROUND_HALF_UP
+Money.default_currency = Money::Currency.new("EUR")


### PR DESCRIPTION
Add ruby money via a concern in the models.

That concern adds a new method with naming following the pattern: `<attribute>_money` and return the Money version